### PR TITLE
Fix pull request IDs

### DIFF
--- a/src/action.go
+++ b/src/action.go
@@ -65,7 +65,7 @@ func updateOrCreateDraftRelease(a *Action, cfg *config.RepoConfig) (*gitea.Relea
 				fmt.Fprintf(&b, "## %s\n\n", strings.Title(label))
 
 				for _, pr := range prs {
-					fmt.Fprintf(&b, "* %s (#%d) @%s\n", pr.Title, pr.ID, pr.Poster.UserName)
+					fmt.Fprintf(&b, "* %s (#%d) @%s\n", pr.Title, pr.Index, pr.Poster.UserName)
 				}
 
 				b.WriteString("\n")


### PR DESCRIPTION
Just tried out your action after upgrading our Gitea, since this is one of the ones I miss the most from GitHub. Thanks for publishing it!

Most things seem to work just fine already. However, PR IDs seem to be using the wrong ID from the database. In my drafts, they use what is the internal `id` column, while the public PR ID seems to be coming from the `index` column instead. This results in broken links and IDs that don't match the ones that users see.
