### PR TITLE
Fix minor version incrementation

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -45,7 +45,7 @@ func ResolveVersion(cfg *config.RepoConfig, last *gitea.Release, changelog *Chan
 		if incMajor {
 			nextVersion = lastVersion.IncMajor()
 		} else if incMinor {
-			nextVersion = lastVersion.IncMajor()
+			nextVersion = lastVersion.IncMinor()
 		} else if incPatch {
 			nextVersion = lastVersion.IncPatch()
 		} else {


### PR DESCRIPTION
Seems like a typo, which results in counting of major numbers when a minor tag is used.